### PR TITLE
Print the remaining request quota in output lines

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     affiliate_window_etl (0.0.1)
       activerecord (~> 5.0)
-      affiliate_window (~> 0.0)
+      affiliate_window (~> 0.1)
       pg (~> 0.19)
 
 GEM
@@ -115,4 +115,4 @@ DEPENDENCIES
   timecop (~> 0.8)
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/affiliate_window_etl.gemspec
+++ b/affiliate_window_etl.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/reevoo/affiliate_window_etl"
   s.files       = ["README.md"] + Dir["lib/**/*.*"]
 
-  s.add_dependency "affiliate_window", "~> 0.0"
+  s.add_dependency "affiliate_window", "~> 0.1"
   s.add_dependency "activerecord", "~> 5.0"
   s.add_dependency "pg", "~> 0.19"
 

--- a/lib/affiliate_window/etl/extracter.rb
+++ b/lib/affiliate_window/etl/extracter.rb
@@ -175,7 +175,8 @@ class AffiliateWindow
 
       def write(message)
         return unless output
-        output.puts(message)
+        message_with_quota = "[quota:#{client.remaining_quota}] #{message}"
+        output.puts(message_with_quota)
       end
     end
   end

--- a/spec/support/fake_client.rb
+++ b/spec/support/fake_client.rb
@@ -86,4 +86,8 @@ class FakeClient
       },
     }
   end
+
+  def remaining_quota
+    14_997
+  end
 end


### PR DESCRIPTION
If we run out of daily quota, things will start breaking so we should keep a close-ish eye on it. Under normal operation, this should never happen, but it's useful to have in the logs.

```
[quota:12345] Extracted commission groups for 123 / 1234 merchants
```
