### PR TITLE
Fix a problem when a response contains a single product

### DIFF
--- a/lib/affiliate_window/etl/extracter.rb
+++ b/lib/affiliate_window/etl/extracter.rb
@@ -102,7 +102,7 @@ class AffiliateWindow
         count = 0
         transaction_ids.each_slice(CHUNK_SIZE) do |ids|
           response = client.get_transaction_product(transaction_ids: ids)
-          transaction_products = response.fetch(:transaction_product)
+          transaction_products = [response.fetch(:transaction_product)].flatten
 
           transaction_products.each do |record|
             yielder.yield(record.merge(record_type: :transaction_product))

--- a/spec/etl/extracter_spec.rb
+++ b/spec/etl/extracter_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe AffiliateWindow::ETL::Extracter do
     ]
   end
 
+  context "when the 'transaction_product' value contains a single record" do
+    it "extracts transactions" do
+      enumerator = subject.extract(:transactions, transaction_ids: [3])
+      records = enumerator.to_a
+
+      expect(records).to eq [
+        { record_type: :transaction, i_id: 3 },
+        { record_type: :transaction_product, name: "iPhone 3" },
+      ]
+    end
+  end
+
   it "extracts daily clicks" do
     enumerator = subject.extract(:daily_clicks, date: "2016-01-01")
     records = enumerator.to_a

--- a/spec/support/fake_client.rb
+++ b/spec/support/fake_client.rb
@@ -54,6 +54,7 @@ class FakeClient
   def get_transaction_product(params)
     transaction_ids = params.fetch(:transaction_ids)
     products = transaction_ids.map { |id| { name: "iPhone #{id}" } }
+    products = products.first if products.size == 1
 
     { transaction_product: products }
   end


### PR DESCRIPTION
The data structure returned from the API is already
flattened when the response array contains a single
element.
