### PR TITLE
Fix etl startup when LAST_N_DAYS is set

### DIFF
--- a/lib/affiliate_window/etl/config.rb
+++ b/lib/affiliate_window/etl/config.rb
@@ -23,7 +23,7 @@ class AffiliateWindow
       end
 
       def last_n_days
-        env.fetch("LAST_N_DAYS", 7)
+        env.fetch("LAST_N_DAYS", "7").to_i
       end
 
       def output_stream


### PR DESCRIPTION
When the LAST_N_DAYS environment variable is set
then the etl fails as environment variables are
always strings... and ruby is a strongly typed language.